### PR TITLE
Add validatePythonCode tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "Backend server for Coding AI IDE using WebSocket, Express, SQLite, and AI providers with project management and Python validation.",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node ../tests/test_validatePythonCode.js"
   },
   "dependencies": {
     "better-sqlite3": "^8.0.1",

--- a/server/validatePythonCode.js
+++ b/server/validatePythonCode.js
@@ -1,0 +1,42 @@
+const { spawn } = require('child_process');
+
+async function validatePythonCode(code, ws, logger = () => {}) {
+    let errors = [];
+    try {
+        // Syntax validation using Python AST
+        const pyCompile = spawn('python', ['-c', 'import sys,ast; ast.parse(sys.stdin.read())']);
+        pyCompile.stdin.write(code);
+        pyCompile.stdin.end();
+
+        const stderrPyCompile = await new Promise(resolve => {
+            let err = '';
+            pyCompile.stderr.on('data', data => { err += data.toString(); });
+            pyCompile.on('close', () => resolve(err));
+        });
+
+        if (stderrPyCompile.trim()) {
+            errors.push(`Syntax Error: ${stderrPyCompile.trim()}`);
+        }
+
+        // PEP8 validation using pycodestyle
+        const pycodestyle = spawn('pycodestyle', ['-']);
+        pycodestyle.stdin.write(code);
+        pycodestyle.stdin.end();
+
+        const stdoutPycodestyle = await new Promise(resolve => {
+            let out = '';
+            pycodestyle.stdout.on('data', data => { out += data.toString(); });
+            pycodestyle.on('close', () => resolve(out));
+        });
+
+        if (stdoutPycodestyle.trim()) {
+            errors.push(`PEP8 Violations:\n${stdoutPycodestyle.trim()}`);
+        }
+    } catch (e) {
+        logger(ws, `Python validation tool error: ${e.message}. Make sure 'python' and 'pycodestyle' are installed and in PATH.`);
+        errors.push(`Internal validator error: ${e.message}`);
+    }
+    return errors;
+}
+
+module.exports = { validatePythonCode };

--- a/tests/test_validatePythonCode.js
+++ b/tests/test_validatePythonCode.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { validatePythonCode } = require('../server/validatePythonCode');
+
+(async () => {
+  // Valid Python code should yield no errors
+  const validCode = "def add(a, b):\n    return a + b\n";
+  const errorsValid = await validatePythonCode(validCode, null);
+  assert.strictEqual(errorsValid.length, 0, 'Expected no errors for valid Python');
+
+  // Code with syntax error should report a syntax error
+  const syntaxErrorCode = "def bad(:\n    pass\n";
+  const errorsSyntax = await validatePythonCode(syntaxErrorCode, null);
+  assert(errorsSyntax.some(e => e.startsWith('Syntax Error')), 'Expected syntax error');
+
+  // Code with PEP8 violations but valid syntax
+  const pep8Code = "def add(a,b):\n  return a+b\n";
+  const errorsPep8 = await validatePythonCode(pep8Code, null);
+  assert(errorsPep8.some(e => e.startsWith('PEP8 Violations')), 'Expected PEP8 violations');
+
+  console.log('All tests passed');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- extract `validatePythonCode` to its own module
- implement AST-based syntax check and pycodestyle PEP8 check
- add test script for valid, syntax-error and PEP8 error scenarios
- expose a `test` npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687806f4fef483298a90becfb9c24e4b