### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Coding AI IDE contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -133,4 +133,4 @@ A web-based Integrated Development Environment (IDE) designed for coding with AI
 - **SuperGrok**: For higher limits, consider [SuperGrok](https://x.ai/grok) ($300/year).
 
 ## License
-MIT License. See `LICENSE` file (not included here) for details.
+MIT License. See the `LICENSE` file for details.


### PR DESCRIPTION
## Summary
- add a standard MIT `LICENSE`
- update README to reference the license file

## Testing
- `npm test --silent` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68780b08101c832980d5dc5e230d25a2