### PR TITLE
Fix file fetching by project ID

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,11 @@ A web-based Integrated Development Environment (IDE) designed for coding with AI
    node server.js
    ```
    The server runs on `http://localhost:3000` and WebSocket on `ws://localhost:3000`.
+To fetch a file via HTTP, include the project ID in the query string:
+```bash
+curl "http://localhost:3000/file/%2Findex.js?projectId=1"
+```
+
 
 ### Frontend Setup
 1. Navigate to the `client` directory and host it using a static server:

--- a/server/server.js
+++ b/server/server.js
@@ -340,12 +340,12 @@ wss.on('connection', (ws) => {
 
 app.get('/file/:path', (req, res) => {
   const path = decodeURIComponent(req.params.path);
-  const currentProjectId = clientCurrentProject.get(req.ws); // This might not work reliably with HTTP GET as it's not a WebSocket connection. Better to use a WebSocket message for file content retrieval based on active project.
-  if (!currentProjectId) {
+  const projectId = parseInt(req.query.projectId, 10);
+  if (!projectId) {
     return res.status(400).json({ content: '', version: 0, error: 'No project selected' });
   }
-  const file = db.prepare('SELECT content, version, language FROM files WHERE project_id = ? AND path = ?').get(currentProjectId, path);
+  const file = db.prepare('SELECT content, version, language FROM files WHERE project_id = ? AND path = ?').get(projectId, path);
   res.json(file || { content: '', version: 0, language: 'plaintext' });
 });
 
-server.listen(3000, () => console.log('Server running on port 3000'));
+server.listen(3000, () => console.log('Server running on port 3000'))


### PR DESCRIPTION
## Summary
- support projectId query parameter for `/file/:path`
- document the new HTTP usage
- remove stray prompt artifact in `server.js`

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_68780b0185888329af0528a122c69b16