### PR TITLE
Fix missing HTML boilerplate

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,22 @@
-<body>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Coding AI IDE</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-sortablejs/dist/index.umd.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/diff/5.1.0/diff.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.22.6/babel.min.js"></script>
+  </head>
+  <body>
   <div id="root"></div>
   <script type="text/babel">
     const { useState, useEffect, useRef } = React;
@@ -586,3 +604,4 @@
     ReactDOM.render(<App />, document.getElementById('root'));
   </script>
 </body>
+</html>


### PR DESCRIPTION
## Summary
- add standard HTML header
- load CDN scripts for React, Babel and supporting libraries
- close document with `</html>`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68780af69f3483299da542fd1401e6f0