### PR TITLE
Add projectId support for /file endpoint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,8 +53,12 @@ A web-based Integrated Development Environment (IDE) designed for coding with AI
    ```bash
    node server.js
    ```
-   The server runs on `http://localhost:3000` and WebSocket on `ws://localhost:3000`.
+The server runs on `http://localhost:3000` and WebSocket on `ws://localhost:3000`.
 5. To run the tests, install Python 3 and `pycodestyle`. See the `Prerequisites` section of `server/README.md` for details.
+6. Retrieve a file's contents via HTTP using:
+   ```bash
+   curl "http://localhost:3000/file/<path>?projectId=<id>"
+   ```
 
 ### Frontend Setup
 1. Navigate to the `client` directory and host it using a static server:

--- a/server/server.js
+++ b/server/server.js
@@ -340,11 +340,11 @@ wss.on('connection', (ws) => {
 
 app.get('/file/:path', (req, res) => {
   const path = decodeURIComponent(req.params.path);
-  const currentProjectId = clientCurrentProject.get(req.ws); // This might not work reliably with HTTP GET as it's not a WebSocket connection. Better to use a WebSocket message for file content retrieval based on active project.
-  if (!currentProjectId) {
-    return res.status(400).json({ content: '', version: 0, error: 'No project selected' });
+  const projectId = parseInt(req.query.projectId, 10);
+  if (!projectId) {
+    return res.status(400).json({ content: '', version: 0, error: 'Missing projectId query parameter' });
   }
-  const file = db.prepare('SELECT content, version, language FROM files WHERE project_id = ? AND path = ?').get(currentProjectId, path);
+  const file = db.prepare('SELECT content, version, language FROM files WHERE project_id = ? AND path = ?').get(projectId, path);
   res.json(file || { content: '', version: 0, language: 'plaintext' });
 });
 


### PR DESCRIPTION
## Summary
- add `projectId` query parameter to `/file/:path`
- document retrieving a file in README

## Testing
- `node test_validatePythonCode.js`

------
https://chatgpt.com/codex/tasks/task_e_68781ed72d3c8329aabce0da96ac2511