### PR TITLE
Add cleanup on WebSocket close

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -338,6 +338,12 @@ wss.on('connection', (ws) => {
       ws.send(JSON.stringify({ type: 'export', files: projectFilesMap }));
     }
   });
+
+  ws.on('close', () => {
+    clientSettings.delete(ws);
+    clientCurrentProject.delete(ws);
+    logEvent(null, 'Client disconnected');
+  });
 });
 
 app.get('/file/:path', (req, res) => {


### PR DESCRIPTION
## Summary
- add `ws.on('close')` to cleanup when a client disconnects
- remove the socket's settings and project mapping
- log the disconnect event

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68782808f30483298d2f8224960dea95