### PR TITLE
Add CI workflow for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - name: Install server dependencies
+      run: |
+        cd server
+        npm ci
+    - name: Install Python dependencies
+      run: python3 -m pip install pycodestyle
+    - name: Run tests
+      run: |
+        cd server
+        npm test
+        node ../tests/test_failover.js


### PR DESCRIPTION
## Summary
- run backend unit tests via GitHub Actions

## Testing
- `npm test` in `server`
- `node ../tests/test_failover.js`

------
https://chatgpt.com/codex/tasks/task_e_687829992b108329a7fe241c2320acec