### PR TITLE
Fix npm install command in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install server dependencies
       run: |
         cd server
-        npm ci
+        npm install
     - name: Install Python dependencies
       run: python3 -m pip install pycodestyle
     - name: Run tests


### PR DESCRIPTION
## Summary
- update the unit test workflow to use `npm install` instead of `npm ci`

## Testing
- `npm install` *(fails: better-sqlite3 compile error)*
- `npm test` *(fails: ws module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a906c71483299a726868b20c96c4