### PR TITLE
Enable coverage and fix tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,14 +5,19 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node ../tests/test_validatePythonCode.js && node ../tests/test_failover.js && node ../tests/test_server_integration.js"
+    "test": "node ../tests/test_validatePythonCode.js && node ../tests/test_failover.js && node ../tests/test_server_integration.js",
+    "coverage": "c8 npm test"
   },
   "dependencies": {
-    "better-sqlite3": "^8.0.1",
+    "better-sqlite3": "^12.2.0",
     "diff": "^5.1.0",
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
     "openai": "^4.29.2",
     "ws": "^8.15.1"
+  },
+  "devDependencies": {
+    "@bcoe/v8-coverage": "^1.0.2",
+    "c8": "^10.1.3"
   }
 }


### PR DESCRIPTION
## Summary
- update `better-sqlite3` to a version supporting Node 22
- add `c8` and `@bcoe/v8-coverage` for coverage reporting
- expose an npm `coverage` script

## Testing
- `npm test`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6878bd2ea3708329bc50e97108a5afae